### PR TITLE
Adapt spin down/up detection to Unraid ge 6.9.0 and SAS

### DIFF
--- a/source/ca.turbo/usr/local/emhttp/plugins/ca.turbo/scripts/auto_turbo.php
+++ b/source/ca.turbo/usr/local/emhttp/plugins/ca.turbo/scripts/auto_turbo.php
@@ -77,12 +77,19 @@ while (true) {
   $validDisks = getDisks();
   $totalSpunDown = 0;
   foreach ($validDisks as $disk) {
-    $result = shell_exec("hdparm -C /dev/{$disk['device']}");
-    if ( $debug ) {
-      logger($result);
-    }
-    if ( ! strpos($result,"active") ) {
-      $totalSpunDown++;
+    if ( file_exists("/usr/local/sbin/sdspin") ) {
+      exec("/usr/local/sbin/sdspin /dev/{$disk['device']}",$out,$ret);
+      if ( $ret == 2 ) {
+        $totalSpunDown++;
+      }
+    } else {
+      $result = shell_exec("hdparm -C /dev/{$disk['device']}");
+      if ( $debug ) {
+        logger($result);
+      }
+      if ( ! strpos($result,"active") ) {
+        $totalSpunDown++;
+      }
     }
   }
   if ( $debug ) {


### PR DESCRIPTION
hdparm does not detect SAS drives power state correctly. Unraid 6.9.0 introduced "sdspin", which is the focal point for spin down detection.
With SAS spindown plugin installed, sdspin correctly detects power state for all drives.